### PR TITLE
convert.go: memseting outputChars to zeroes to avoid garbage in output

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -140,6 +140,7 @@ func convertWcharStringToGoString(ws WcharString) (output string, err error) {
 	// create output buffer
 	outputChars := (*C.char)(C.malloc(bytesLeftOutCSize))
 	defer C.free(unsafe.Pointer(outputChars))
+	C.memset(unsafe.Pointer(outputChars), C.int(0), bytesLeftOutCSize)
 
 	// call iconv for conversion of charsets, return on error
 	saveInputAsCChars, saveOutputChars := inputAsCChars, outputChars


### PR DESCRIPTION
Sometimes the size of outputChars should be smaller. UTF-8 is more compact. For example in the arabic letters wchar_t (on mac and linux) is of size 4 bytes while in UTF-8 they would only take 2 bytes.
Not setting outputChars to zero caused a lot of garbage in the output instead of letting `C.GoString` find the null terminator early on.
